### PR TITLE
Creates per-os maps for dotnet hotfixes

### DIFF
--- a/dotnet4/init.sls
+++ b/dotnet4/init.sls
@@ -9,9 +9,8 @@ dotnet4:
     - kwargs:
         version: {{ dotnet4.version }}
     - onlyif: 'powershell.exe -noprofile -command
-        "if (\"{{ dotnet4.hotfix_id }}\" -in (get-wmiobject -class
-                                         win32_quickfixengineering).HotFixID) {
-            echo \".NET {{ dotnet4.version }} already installed\"; exit 1
+        "if (@({{ dotnet4.hotfix_ids | map('tojson') | join(',') | replace('"','\\"') }}) |? { @((get-wmiobject -class win32_quickfixengineering).HotFixID) -contains $_ }) {
+            echo \".NET {{ dotnet4.version }} or greater already installed\"; exit 1
         }"
     '
 {%- else %}

--- a/dotnet4/init.sls
+++ b/dotnet4/init.sls
@@ -1,8 +1,6 @@
 {%- from "dotnet4/map.jinja" import dotnet4 with context %}
 
-{%- set osrelease = salt['grains.get']('osrelease','') %}
-
-{%- if osrelease in dotnet4.hotfix_os %}
+{%- if dotnet4.hotfix_os %}
 {#- For win8 or later, or ws2012 or later, use the pkg *module* to install .NET. #}
 dotnet4:
   module.run:

--- a/dotnet4/map.jinja
+++ b/dotnet4/map.jinja
@@ -50,5 +50,5 @@
         dotnet_ver_to_hotfix,
         grain='osrelease',
     )[dotnet4['version']],
-    'hotfix_os': dotnet_ver_to_hotfix.keys()
+    'hotfix_os': salt.grains.get('osrelease', '') in dotnet_ver_to_hotfix.keys()
 }) %}

--- a/dotnet4/map.jinja
+++ b/dotnet4/map.jinja
@@ -3,10 +3,6 @@
     'version'     : '4.6.01590',
 } %}
 
-{% set hotfix_os = [
-    '8.1', '10', '2012ServerR2', '2016Server'
-] %}
-
 {#
     On Windows 8 or later, and Windows Server 2012 or later, .NET is built into
     the OS in a way that pkg.installed cannot check for. .NET only shows up in
@@ -16,17 +12,43 @@
 #}
 
 {% set dotnet_ver_to_hotfix = {
-    '4.5.51209' : 'KB2934520',
-    '4.6.00081' : 'KB3045563',
-    '4.6.01055' : 'KB3102467',
-    '4.6.01590' : 'KB3151864',
+    '8.1': {
+        '4.5.51209' : 'KB2934520',
+        '4.6.00081' : 'KB3045563',
+        '4.6.01055' : 'KB3102467',
+        '4.6.01590' : 'KB3151864',
+        '4.7.02053' : 'KB3186539',
+        '4.7.02558' : 'KB4033369',
+    },
+    '10': {
+        '4.6.01055' : 'KB3102495',
+        '4.6.01590' : 'KB3151900',
+        '4.7.02053' : 'KB3186568',
+        '4.7.02558' : 'KB4033393',
+    },
+    '2012ServerR2': {
+        '4.5.51209' : 'KB2934520',
+        '4.6.00081' : 'KB3045563',
+        '4.6.01055' : 'KB3102467',
+        '4.6.01590' : 'KB3151864',
+        '4.7.02053' : 'KB3186539',
+        '4.7.02558' : 'KB4033369',
+    },
+    '2016Server': {
+        '4.6.01590' : 'KB3151900',
+        '4.7.02053' : 'KB3186568',
+        '4.7.02558' : 'KB4033393',
+    }
 } %}
 
 # Over-ride defaults with user-defined settings from pillar (if available)
-{% do dotnet4.update(salt['pillar.get']('dotnet4:lookup', {})) %}
+{% do dotnet4.update(salt.pillar.get('dotnet4:lookup', {})) %}
 
 # Add dotnet kb to the dotnet dictionary
 {% do dotnet4.update({
-    'hotfix_id': dotnet_ver_to_hotfix[dotnet4['version']],
-    'hotfix_os' : hotfix_os
+    'hotfix_id': salt.grains.filter_by(
+        dotnet_ver_to_hotfix,
+        grain='osrelease',
+    )[dotnet4['version']],
+    'hotfix_os': dotnet_ver_to_hotfix.keys()
 }) %}

--- a/dotnet4/map.jinja
+++ b/dotnet4/map.jinja
@@ -1,6 +1,7 @@
 # Initialize 'dotnet4' dictionary with default settings for the dotnet4 formula
 {% set dotnet4 = {
-    'version'     : '4.6.01590',
+    'version': '4.6.01590',
+    'hotfix_os': False,
 } %}
 
 {#
@@ -41,14 +42,18 @@
     }
 } %}
 
-# Over-ride defaults with user-defined settings from pillar (if available)
+# Override defaults with user-defined settings from pillar (if available)
 {% do dotnet4.update(salt.pillar.get('dotnet4:lookup', {})) %}
 
-# Add dotnet kb to the dotnet dictionary
-{% do dotnet4.update({
-    'hotfix_id': salt.grains.filter_by(
-        dotnet_ver_to_hotfix,
-        grain='osrelease',
-    )[dotnet4['version']],
-    'hotfix_os': salt.grains.get('osrelease', '') in dotnet_ver_to_hotfix.keys()
-}) %}
+# Add dotnet hotfix ids to the dotnet dictionary
+{% if salt.grains.get('osrelease', '') in dotnet_ver_to_hotfix.keys() %}
+  {% set hotfix_map = salt.grains.filter_by(
+      dotnet_ver_to_hotfix,
+      grain='osrelease',
+  ) %}
+
+  {% do dotnet4.update({
+      'hotfix_ids': hotfix_map.values()[hotfix_map.keys().index(dotnet4['version']):],
+      'hotfix_os': True,
+  }) %}
+{% endif %}


### PR DESCRIPTION
This patch creates a map for each os that treats dotnet as a hotfix, since the hotfix id may vary per os. The dotnet versions listed in the maps at this time are the versions that appear to be supported with the corresponding os version.

It also updates the formula so that will skip installing dotnet as a hotfix if a newer version is already installed. This was already the behavior where dotnet is listed as an installed package (rather than a hotfix).