### PR TITLE
Add list filter to support Salt 2018.3.4 PY3

### DIFF
--- a/dotnet4/map.jinja
+++ b/dotnet4/map.jinja
@@ -57,7 +57,7 @@
   ) %}
 
   {% do dotnet4.update({
-      'hotfix_ids': hotfix_map.values()[hotfix_map.keys().index(dotnet4['version']):],
+      'hotfix_ids': (hotfix_map.values()|list)[(hotfix_map.keys()|list).index(dotnet4['version']):],
       'hotfix_os': True,
   }) %}
 {% endif %}


### PR DESCRIPTION
This change fixes the following error when using the dotnet4-formula with Salt 2018.3.4 PY3:
```
[CRITICAL][3392] Rendering SLS 'base:dotnet4' failed: Jinja variable 'dict_keys object' has no attribute 'index'
c:\salt\var\cache\salt\minion\files\base\dotnet4/map.jinja(59):
---
[...]
  {% set hotfix_map = salt.grains.filter_by(
      dotnet_ver_to_hotfix,
      grain='osrelease',
  ) %}

  {% do dotnet4.update({    <======================
      'hotfix_ids': hotfix_map.values()[hotfix_map.keys().index(dotnet4['version']):],
      'hotfix_os': True,
  }) %}
{% endif %}
---
```

Modification has been verified to also work on older PY2 versions of Salt (v2018.3.3, v2016.11.6)